### PR TITLE
feat: add AWS Bedrock LLM provider support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@ai-sdk-tools/store": "^1.2.0",
+    "@ai-sdk/amazon-bedrock": "^4.0.100",
     "@ai-sdk/anthropic": "3.0.15",
     "@ai-sdk/google": "3.0.10",
     "@ai-sdk/groq": "3.0.10",

--- a/src/components/add-llm-key-dialog.tsx
+++ b/src/components/add-llm-key-dialog.tsx
@@ -76,6 +76,10 @@ const providerApiKeyUrls: Partial<
 		url: "https://console.mistral.ai/api-keys",
 		label: "Mistral Console",
 	},
+	[LLMProvider.BEDROCK]: {
+		url: "https://console.aws.amazon.com/iam/home#/security_credentials",
+		label: "AWS IAM Console",
+	},
 };
 
 interface AddLLMKeyDialogProps {
@@ -245,12 +249,20 @@ export function AddLLMKeyDialog({
 							name="apiKey"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel className="text-sm font-medium">API Key</FormLabel>
+									<FormLabel className="text-sm font-medium">
+										{form.watch("provider") === LLMProvider.BEDROCK
+											? "Credentials (JSON)"
+											: "API Key"}
+									</FormLabel>
 									<FormControl>
 										<div className="relative">
 											<Input
 												type="password"
-												placeholder="sk-... or your provider's API key format"
+												placeholder={
+													form.watch("provider") === LLMProvider.BEDROCK
+														? '{"accessKeyId":"...","secretAccessKey":"...","region":"us-east-1"}'
+														: "sk-... or your provider's API key format"
+												}
 												className="h-12 pl-4 pr-4"
 												{...field}
 												autoComplete="off"

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -579,6 +579,35 @@ export const Qwen = (props: SVGProps<SVGSVGElement>) => (
 	</svg>
 );
 
+export const AWSBedrock = (props: SVGProps<SVGSVGElement>) => (
+	<svg
+		{...props}
+		viewBox="0 0 40 40"
+		xmlns="http://www.w3.org/2000/svg"
+		width="1em"
+		height="1em"
+	>
+		<title>AWS Bedrock</title>
+		<path
+			d="M20 3L3 12.5v15L20 37l17-9.5v-15L20 3z"
+			fill="#232F3E"
+		/>
+		<path
+			d="M20 6.5L6 14.5v11L20 33.5l14-8v-11L20 6.5z"
+			fill="#FF9900"
+		/>
+		<path
+			d="M20 10l-10 5.5v9L20 30l10-5.5v-9L20 10z"
+			fill="#232F3E"
+		/>
+		<path
+			d="M20 13.5l-6.5 3.5v6l6.5 3.5 6.5-3.5v-6L20 13.5z"
+			fill="#FF9900"
+			opacity="0.85"
+		/>
+	</svg>
+);
+
 export const llmProviderIcons = {
 	[LLMProvider.ANTHROPIC]: AnthropicLogo,
 	[LLMProvider.OPENAI]: OpenAILogo,
@@ -587,6 +616,7 @@ export const llmProviderIcons = {
 	[LLMProvider.GROQ]: Groq,
 	[LLMProvider.ALIBABA]: Qwen,
 	[LLMProvider.GITHUB_MODELS]: MdiGithub,
+	[LLMProvider.BEDROCK]: AWSBedrock,
 };
 
 /**

--- a/src/integrations/trpc/router/llm-provider.ts
+++ b/src/integrations/trpc/router/llm-provider.ts
@@ -168,6 +168,8 @@ function getProviderDescription(provider: LLMProvider): string {
 			return "GitHub Models marketplace with various AI models";
 		case LLMProvider.MISTRAL:
 			return "Mistral AI's models including Mistral Large, Medium, and Small";
+		case LLMProvider.BEDROCK:
+			return "AWS Bedrock with access to Claude, Llama, Titan, and other foundation models";
 		default:
 			return "";
 	}

--- a/src/lib/models-dev.ts
+++ b/src/lib/models-dev.ts
@@ -14,6 +14,7 @@ const PROVIDER_ID_MAP: Record<LLMProvider, string> = {
 	[LLMProvider.GROQ]: "groq",
 	[LLMProvider.GITHUB_MODELS]: "github-models",
 	[LLMProvider.MISTRAL]: "mistral",
+	[LLMProvider.BEDROCK]: "amazon-bedrock",
 };
 
 /**

--- a/src/routes/api/chat/-libs/models.ts
+++ b/src/routes/api/chat/-libs/models.ts
@@ -1,3 +1,4 @@
+import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import {
 	type AnthropicProviderOptions,
 	createAnthropic,
@@ -63,6 +64,20 @@ export function getAIModel(
 				baseURL: "https://models.github.ai/inference",
 				name: "github-models",
 			})(model || "gpt-4.1-mini");
+
+		case LLMProvider.BEDROCK: {
+			// apiKey is JSON: {"accessKeyId":"...","secretAccessKey":"...","region":"..."}
+			const creds = JSON.parse(apiKey) as {
+				accessKeyId: string;
+				secretAccessKey: string;
+				region: string;
+			};
+			return createAmazonBedrock({
+				accessKeyId: creds.accessKeyId,
+				secretAccessKey: creds.secretAccessKey,
+				region: creds.region || "us-east-1",
+			})(model || "anthropic.claude-3-5-sonnet-20241022-v2:0");
+		}
 
 		default:
 			throw new Error(`Unsupported provider: ${provider}`);

--- a/src/services/llm-provider-service.ts
+++ b/src/services/llm-provider-service.ts
@@ -289,6 +289,124 @@ export async function validateMistralKey(
 	}
 }
 
+export async function validateBedrockKey(
+	apiKey: string,
+): Promise<{ isValid: boolean; models?: string[]; error?: string }> {
+	try {
+		const creds = JSON.parse(apiKey) as {
+			accessKeyId?: string;
+			secretAccessKey?: string;
+			region?: string;
+		};
+
+		if (!creds.accessKeyId || !creds.secretAccessKey) {
+			return {
+				isValid: false,
+				error: "accessKeyId and secretAccessKey are required",
+			};
+		}
+
+		const region = creds.region || "us-east-1";
+
+		// Call the Bedrock ListFoundationModels API to validate credentials
+		const host = `bedrock.${region}.amazonaws.com`;
+		const endpoint = `https://${host}/foundation-models`;
+
+		// AWS Signature V4 signing
+		const now = new Date();
+		const amzDate =
+			now.toISOString().replace(/[:-]|\.\d{3}/g, "").slice(0, 15) + "Z";
+		const dateStamp = amzDate.slice(0, 8);
+
+		const canonicalUri = "/foundation-models";
+		const canonicalQueryString = "";
+		const canonicalHeaders = `host:${host}\nx-amz-date:${amzDate}\n`;
+		const signedHeaders = "host;x-amz-date";
+
+		const encoder = new TextEncoder();
+
+		async function sha256Hex(data: string): Promise<string> {
+			const buf = await crypto.subtle.digest("SHA-256", encoder.encode(data));
+			return Array.from(new Uint8Array(buf))
+				.map((b) => b.toString(16).padStart(2, "0"))
+				.join("");
+		}
+
+		async function hmacSha256(key: ArrayBuffer, data: string): Promise<ArrayBuffer> {
+			const cryptoKey = await crypto.subtle.importKey(
+				"raw",
+				key,
+				{ name: "HMAC", hash: "SHA-256" },
+				false,
+				["sign"],
+			);
+			return crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(data));
+		}
+
+		const payloadHash = await sha256Hex("");
+		const canonicalRequest = [
+			"GET",
+			canonicalUri,
+			canonicalQueryString,
+			canonicalHeaders,
+			signedHeaders,
+			payloadHash,
+		].join("\n");
+
+		const credentialScope = `${dateStamp}/${region}/bedrock/aws4_request`;
+		const stringToSign = [
+			"AWS4-HMAC-SHA256",
+			amzDate,
+			credentialScope,
+			await sha256Hex(canonicalRequest),
+		].join("\n");
+
+		const kDate = await hmacSha256(
+			encoder.encode(`AWS4${creds.secretAccessKey}`),
+			dateStamp,
+		);
+		const kRegion = await hmacSha256(kDate, region);
+		const kService = await hmacSha256(kRegion, "bedrock");
+		const kSigning = await hmacSha256(kService, "aws4_request");
+		const signatureBuf = await hmacSha256(kSigning, stringToSign);
+		const signature = Array.from(new Uint8Array(signatureBuf))
+			.map((b) => b.toString(16).padStart(2, "0"))
+			.join("");
+
+		const authHeader = `AWS4-HMAC-SHA256 Credential=${creds.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+		const response = await fetch(endpoint, {
+			method: "GET",
+			headers: {
+				Authorization: authHeader,
+				"x-amz-date": amzDate,
+			},
+		});
+
+		if (response.ok) {
+			const data = await response.json();
+			const models: string[] =
+				data.modelSummaries?.map(
+					(m: { modelId: string }) => m.modelId,
+				) ?? [];
+			return { isValid: true, models };
+		}
+
+		const errorData = await response.json().catch(() => ({}));
+		return {
+			isValid: false,
+			error:
+				(errorData as { message?: string }).message ||
+				`HTTP ${response.status}`,
+		};
+	} catch (error) {
+		return {
+			isValid: false,
+			error: error instanceof Error ? error.message : "Invalid credentials JSON",
+		};
+	}
+}
+
 export async function validateApiKey(provider: LLMProvider, apiKey: string) {
 	switch (provider) {
 		case LLMProvider.OPENAI:
@@ -305,6 +423,8 @@ export async function validateApiKey(provider: LLMProvider, apiKey: string) {
 			return await validateGitHubModelsKey(apiKey);
 		case LLMProvider.MISTRAL:
 			return await validateMistralKey(apiKey);
+		case LLMProvider.BEDROCK:
+			return await validateBedrockKey(apiKey);
 		default:
 			return { isValid: false, error: "Unsupported provider" };
 	}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -9,6 +9,7 @@ export enum LLMProvider {
 	GROQ = "groq",
 	GITHUB_MODELS = "github-models",
 	MISTRAL = "mistral",
+	BEDROCK = "bedrock",
 }
 
 export const supportedLLMProviders = Object.values(LLMProvider);


### PR DESCRIPTION
## Summary

Adds AWS Bedrock as a supported LLM provider.

## Changes

- **`@ai-sdk/amazon-bedrock`** installed as a dependency
- **`LLMProvider` enum** — added `BEDROCK = "bedrock"`
- **`getAIModel()`** — Bedrock case parses JSON credentials (`accessKeyId`, `secretAccessKey`, `region`) and calls `createAmazonBedrock`; defaults to `anthropic.claude-3-5-sonnet-20241022-v2:0`
- **`validateBedrockKey()`** — validates credentials via AWS Signature V4 signed request to `bedrock.{region}.amazonaws.com/foundation-models`
- **`llmProviderIcons`** — added `AWSBedrock` SVG icon
- **`PROVIDER_ID_MAP`** — mapped `BEDROCK → "amazon-bedrock"` for models.dev integration
- **`add-llm-key-dialog`** — shows JSON format hint as placeholder and links to AWS IAM Console

## Usage

When adding a Bedrock key in the UI, enter credentials as JSON:
```json
{"accessKeyId": "AKIA...", "secretAccessKey": "...", "region": "us-east-1"}
```

The IAM user/role needs `AmazonBedrockFullAccess` or at minimum `bedrock:ListFoundationModels` + `bedrock:InvokeModel`.